### PR TITLE
add Tomee NES to USB support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ nes-controller
 ==============
 
 Interface to a
-[Gtron USB Nintendo Entertainment System controller](http://www.amazon.com/gp/product/B002YVD3KM).
+[Gtron USB Nintendo Entertainment System controller](http://www.amazon.com/gp/product/B002YVD3KM) or [Tomee NES to USB adapter](http://www.amazon.com/gp/product/B00HM3QCN2).
 Forked from [@dustMason](https://github.com/dustMason)'s [n64controller](https://github.com/dustMason/n64controller) module.
 
 `npm install nes-controller`

--- a/index.js
+++ b/index.js
@@ -24,6 +24,18 @@ var definitions = {
             "EW" : 3,
             "NS" : 4
         }
+    },
+    "NES PC Game Pad" : {
+        "buttons": {
+            "A":        [5, 0x20],
+            "B":        [5, 0x10],
+            "SELECT":   [5, 0x40],
+            "START":    [5, 0x80],
+        },
+        "dpad" : {
+            "EW" : 0,
+            "NS" : 4
+        }        
     }
 }
 


### PR DESCRIPTION
Supports this NES to USB adapter: http://amzn.to/1KyVAHT
