### PR TITLE
node-hid reports this as "USB Gamepad" for me, not "USB Gamepad "

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var definitions = {
             "NS" : 1
         }
     },
-    "USB Gamepad " : {
+    "USB Gamepad" : {
         "buttons": {
             "A":        [5, 0x20],
             "B":        [5, 0x40],


### PR DESCRIPTION
This change allows both ways to work.
